### PR TITLE
[Fix] Paramtype error in generator

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -83,7 +83,7 @@ class Generator
      * Get the current number of a register for informational output.
      * Must not be used for incrementational purposes.
      *
-     * @param $register the register name
+     * @param string $register the register name
      *
      * @return int >= 0
      */


### PR DESCRIPTION
phpdoc thought that "the" was the param type. Adding string before register to make sure code completion does not show a warning that you do not provide the wrong type "the".