### PR TITLE
CI: replace pwn-request php-cs-fixer and repoint dead static-analysis reference

### DIFF
--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -1,35 +1,23 @@
 name: "PHP-CS-Fixer"
 
 on:
-    pull_request_target:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-            - "feature-*"
-    push:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-            - "*_actions"
-            - "feature-*"
+  workflow_dispatch:
+  push:
+    branches:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
+      - "*_actions"
+      - "feature-*"
 
 permissions:
-    contents: read
+  contents: write
 
 jobs:
-    php-cs-fixer:
-        permissions:
-            contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  ref: ${{ github.event.pull_request.head.ref }}
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-            - name: PHP-CS-Fixer
-              uses: docker://oskarstark/php-cs-fixer-ga:latest
-
-            - uses: stefanzweifel/git-auto-commit-action@v5
-              with:
-                  commit_message: Apply php-cs-fixer changes
+  php-style:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@main
+    with:
+      head_ref: ${{ github.head_ref || github.ref_name }}
+      repository: ${{ github.repository }}
+      config_file: ".php-cs-fixer.dist.php"
+    secrets:
+      PHP_CS_FIXER_GITHUB_TOKEN: ${{ secrets.PHP_CS_FIXER_GITHUB_TOKEN }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,54 +1,84 @@
-name: "Static Analysis"
+name: "Static analysis centralised"
 
 on:
-    pull_request:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-    push:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
+  schedule:
+    - cron: '0 3 * * 1,3,5'
+  workflow_dispatch:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+    branches:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
+
+env:
+  PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
+  PRIVATE_REPO: ${{ github.event.repository.private }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
-    static-analysis-phpstan:
-        name: "Static Analysis with PHPStan"
-        runs-on: "ubuntu-20.04"
-        strategy:
-            matrix:
-                include:
-                    - { php-version: "8.0", database: "mariadb:10.7", dependencies: "lowest", pimcore_version: "", phpstan_args: "", experimental: false }
-                    - { php-version: "8.1", database: "mariadb:10.7", dependencies: "highest", pimcore_version: "", phpstan_args: "", experimental: false }
-                    - { php-version: "8.1", database: "mariadb:10.7", dependencies: "highest", pimcore_version: "11.x-dev", phpstan_args: "", experimental: true }
-        steps:
-            - name: "Checkout code"
-              uses: "actions/checkout@v2"
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
+      phpstan_matrix: ${{ steps.set-matrix.outputs.phpstan_matrix }}
+      private_repo: ${{ env.PRIVATE_REPO }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: "Install PHP"
-              uses: "shivammathur/setup-php@v2"
-              with:
-                  coverage: "none"
-                  php-version: "${{ matrix.php-version }}"
+      - name: Checkout reusable workflow repo
+        uses: actions/checkout@v4
+        with:
+          repository: pimcore/workflows-collection-public
+          ref: main
+          path: reusable-workflows
 
-            - name: "Setup Pimcore environment"
-              run: |
-                  .github/ci/scripts/setup-pimcore-environment.sh
-            - name: "Update Pimcore version"
-              env:
-                  PIMCORE_VERSION: "${{ matrix.pimcore_version }}"
-              run: |
-                  if [ ! -z "$PIMCORE_VERSION" ]; then
-                        composer require --no-update pimcore/pimcore:"${PIMCORE_VERSION} as 11.99.9"
-                  fi
-            - name: "Install dependencies with Composer"
-              uses: "ramsey/composer-install@v2"
-              with:
-                  dependency-versions: "${{ matrix.dependencies }}"
+      - name: Parse PHP versions from composer.json
+        id: parse-php-versions
+        run: |
+          if [ -f composer.json ]; then
+            php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | tr '\n' ',' | sed 's/,$//')
+            if [ -z "$php_versions" ]; then
+              echo "php_versions=default" >> "$GITHUB_OUTPUT"
+            else
+              echo "php_versions=$php_versions" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            exit 1
+          fi
 
-            - name: "Run a static analysis with phpstan/phpstan (highest)"
-              if: ${{ matrix.dependencies == 'highest' }}
-              run: "vendor/bin/phpstan analyse --memory-limit=-1"
+      - name: Set up matrix JSON
+        id: set-matrix
+        run: |
+          php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
+          MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
+          FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '{ include: [ .configs[] | select(.php_version == $php_versions) | .matrix[] ] }')
+          ENCODED_MATRIX_JSON=$(echo "$FILTERED_MATRIX_JSON" | jq -c .)
+          echo "phpstan_matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
 
-            - name: "Run a static analysis with phpstan/phpstan (lowest)"
-              if: ${{ matrix.dependencies == 'lowest' }}
-              run: "vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan-lowest.neon"
+  static-analysis:
+    needs: setup-matrix
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-unified.yaml@main
+    with:
+      phpstan_matrix: ${{ needs.setup-matrix.outputs.phpstan_matrix }}
+      private_repo: ${{ needs.setup-matrix.outputs.private_repo }}
+      APP_ENV: test
+      PIMCORE_TEST: 1
+      REQUIRE_ADMIN_BUNDLE: "false"
+      COVERAGE: "none"
+    secrets:
+      SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
+      COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
+      PIMCORE_CI_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}
+      PIMCORE_CI_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_CI_ENCRYPTION_SECRET }}
+      PIMCORE_CI_PRODUCT_KEY: ${{ secrets.PIMCORE_CI_PRODUCT_KEY }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,84 +1,54 @@
-name: "Static analysis centralised"
+name: "Static Analysis"
 
 on:
-  schedule:
-    - cron: '0 3 * * 1,3,5'
-  workflow_dispatch:
-  pull_request:
-    types: [ opened, synchronize, reopened ]
-    paths-ignore:
-      - 'doc/**'
-      - '**.md'
-  push:
-    paths-ignore:
-      - 'doc/**'
-      - '**.md'
-    branches:
-      - "[0-9]+.[0-9]+"
-      - "[0-9]+.x"
-
-env:
-  PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
-  PRIVATE_REPO: ${{ github.event.repository.private }}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+    pull_request:
+        branches:
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
+    push:
+        branches:
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
 
 jobs:
-  setup-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
-      phpstan_matrix: ${{ steps.set-matrix.outputs.phpstan_matrix }}
-      private_repo: ${{ env.PRIVATE_REPO }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    static-analysis-phpstan:
+        name: "Static Analysis with PHPStan"
+        runs-on: "ubuntu-20.04"
+        strategy:
+            matrix:
+                include:
+                    - { php-version: "8.0", database: "mariadb:10.7", dependencies: "lowest", pimcore_version: "", phpstan_args: "", experimental: false }
+                    - { php-version: "8.1", database: "mariadb:10.7", dependencies: "highest", pimcore_version: "", phpstan_args: "", experimental: false }
+                    - { php-version: "8.1", database: "mariadb:10.7", dependencies: "highest", pimcore_version: "11.x-dev", phpstan_args: "", experimental: true }
+        steps:
+            - name: "Checkout code"
+              uses: "actions/checkout@v2"
 
-      - name: Checkout reusable workflow repo
-        uses: actions/checkout@v4
-        with:
-          repository: pimcore/workflows-collection-public
-          ref: main
-          path: reusable-workflows
+            - name: "Install PHP"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  coverage: "none"
+                  php-version: "${{ matrix.php-version }}"
 
-      - name: Parse PHP versions from composer.json
-        id: parse-php-versions
-        run: |
-          if [ -f composer.json ]; then
-            php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | tr '\n' ',' | sed 's/,$//')
-            if [ -z "$php_versions" ]; then
-              echo "php_versions=default" >> "$GITHUB_OUTPUT"
-            else
-              echo "php_versions=$php_versions" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            exit 1
-          fi
+            - name: "Setup Pimcore environment"
+              run: |
+                  .github/ci/scripts/setup-pimcore-environment.sh
+            - name: "Update Pimcore version"
+              env:
+                  PIMCORE_VERSION: "${{ matrix.pimcore_version }}"
+              run: |
+                  if [ ! -z "$PIMCORE_VERSION" ]; then
+                        composer require --no-update pimcore/pimcore:"${PIMCORE_VERSION} as 11.99.9"
+                  fi
+            - name: "Install dependencies with Composer"
+              uses: "ramsey/composer-install@v2"
+              with:
+                  dependency-versions: "${{ matrix.dependencies }}"
 
-      - name: Set up matrix JSON
-        id: set-matrix
-        run: |
-          php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
-          MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
-          FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '{ include: [ .configs[] | select(.php_version == $php_versions) | .matrix[] ] }')
-          ENCODED_MATRIX_JSON=$(echo "$FILTERED_MATRIX_JSON" | jq -c .)
-          echo "phpstan_matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
+            - name: "Run a static analysis with phpstan/phpstan (highest)"
+              if: ${{ matrix.dependencies == 'highest' }}
+              run: "vendor/bin/phpstan analyse --memory-limit=-1"
 
-  static-analysis:
-    needs: setup-matrix
-    uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-unified.yaml@main
-    with:
-      phpstan_matrix: ${{ needs.setup-matrix.outputs.phpstan_matrix }}
-      private_repo: ${{ needs.setup-matrix.outputs.private_repo }}
-      APP_ENV: test
-      PIMCORE_TEST: 1
-      REQUIRE_ADMIN_BUNDLE: "false"
-      COVERAGE: "none"
-    secrets:
-      SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
-      COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
-      PIMCORE_CI_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}
-      PIMCORE_CI_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_CI_ENCRYPTION_SECRET }}
-      PIMCORE_CI_PRODUCT_KEY: ${{ secrets.PIMCORE_CI_PRODUCT_KEY }}
+            - name: "Run a static analysis with phpstan/phpstan (lowest)"
+              if: ${{ matrix.dependencies == 'lowest' }}
+              run: "vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan-lowest.neon"


### PR DESCRIPTION
Security fix (pimcore/service-operations#1083): the inline php-cs-fixer workflow ran under `pull_request_target` with `contents: write` while checking out fork-controlled content — the classic pwn-request. Replaced with the push-only reusable caller this repo already uses on its default branch (byte-identical file swap). Pattern validated on pimcore/web2print-tools#121.

**Scope note:** this PR originally also repointed the static-analysis workflow. That was reverted after verification: this version line cannot install any Pimcore ^10/^11 release under Composer 2.9's Packagist advisory policy, so the unified workflow cannot go green here. The dead-reference repoint landed on the lowest 12-era branch instead; this branch's static-analysis state is documented on pimcore/DevOps-Tasks#47.

**Expected on this PR:** php-cs-fixer does NOT run (push-only trigger). The old-style `Static Analysis` checks pinned to retired ubuntu-20.04 runners queue forever and never conclude — pre-existing on this branch, not caused or required by this PR.  Repoint for this repo: pimcore/number-sequence-generator#56 (@3.0).