### PR TITLE
Repoint static analysis to reusable-static-analysis-unified

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 3 * * 1,3,5'
   workflow_dispatch:
   pull_request:
+    branches:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
+      - "feature-*"
     types: [ opened, synchronize, reopened ]
     paths-ignore:
       - 'doc/**'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,10 +5,6 @@ on:
     - cron: '0 3 * * 1,3,5'
   workflow_dispatch:
   pull_request:
-    branches:
-      - "[0-9]+.[0-9]+"
-      - "[0-9]+.x"
-      - "feature-*"
     types: [ opened, synchronize, reopened ]
     paths-ignore:
       - 'doc/**'
@@ -17,9 +13,6 @@ on:
     paths-ignore:
       - 'doc/**'
       - '**.md'
-    branches:
-      - "[0-9]+.[0-9]+"
-      - "[0-9]+.x"
 
 env:
   PIMCORE_PROJECT_ROOT: ${{ github.workspace }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,95 +1,84 @@
 name: "Static analysis centralised"
 
 on:
-    schedule:
-        -   cron: '0 3 * * 1,3,5'
-    workflow_dispatch:
-    push:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-            - "feature-*"
-    pull_request:
-        types: [ opened, synchronize, reopened ]
-
+  schedule:
+    - cron: '0 3 * * 1,3,5'
+  workflow_dispatch:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+    branches:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
 
 env:
-    PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
-    PRIVATE_REPO: ${{ github.event.repository.private }}
+  PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
+  PRIVATE_REPO: ${{ github.event.repository.private }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-    setup-matrix:
-        runs-on: ubuntu-latest
-        outputs:
-            php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
-            matrix: ${{ steps.set-matrix.outputs.matrix }}
-            private_repo: ${{ env.PRIVATE_REPO }}
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
+      phpstan_matrix: ${{ steps.set-matrix.outputs.phpstan_matrix }}
+      private_repo: ${{ env.PRIVATE_REPO }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Checkout reusable workflow repo
-              uses: actions/checkout@v4
-              with:
-                  repository: pimcore/workflows-collection-public
-                  ref: main
-                  path: reusable-workflows
-
-            - name: Parse PHP versions from composer.json
-              id: parse-php-versions
-              run: |
-                  if [ -f composer.json ]; then
-                    php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | tr '\n' ',' | sed 's/,$//')
-                    if [ -z "$php_versions" ]; then
-                      echo "No PHP versions found in composer.json"
-                      echo "Setting default PHP value"
-                      echo "php_versions=default" >> $GITHUB_OUTPUT
-                    else
-                      echo "php_versions=$php_versions" >> $GITHUB_OUTPUT
-                      echo "#### php versions #### : $php_versions"
-                    fi
-                  else
-                    echo "composer.json not found"
-                    exit 1
-                  fi
-
-            - name: Set up matrix
-              id: set-matrix
-              run: |
-                  php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
-                  
-                  MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
-                  
-                  IFS=',' read -ra VERSIONS_ARRAY <<< "$php_versions"
-                  
-                  FILTERED_MATRIX_JSON=$(echo $MATRIX_JSON | jq --arg php_versions "$php_versions" '
-                  {
-                    matrix: [
-                      .configs[] |
-                      select(.php_version == $php_versions) |
-                      .matrix[]
-                    ]
-                  }')
-                  
-                  ENCODED_MATRIX_JSON=$(echo $FILTERED_MATRIX_JSON | jq -c .)
-                  
-                  echo "matrix=${ENCODED_MATRIX_JSON}" >> $GITHUB_OUTPUT
-
-    static-analysis:
-        needs: setup-matrix
-        strategy:
-            matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
-        uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-centralized.yaml@main
+      - name: Checkout reusable workflow repo
+        uses: actions/checkout@v4
         with:
-            APP_ENV: test
-            PIMCORE_TEST: 1
-            PRIVATE_REPO: ${{ needs.setup-matrix.outputs.private_repo}}
-            PHP_VERSION: ${{ matrix.matrix.php-version }}
-            SYMFONY: ${{ matrix.matrix.symfony }}
-            DEPENDENCIES: ${{ matrix.matrix.dependencies }}
-            EXPERIMENTAL: ${{ matrix.matrix.experimental }}
-            PIMCORE_VERSION: ${{ matrix.matrix.pimcore_version }}
-            COMPOSER_OPTIONS: ${{ matrix.matrix.composer_options }}
-        secrets:
-            SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
-            COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
+          repository: pimcore/workflows-collection-public
+          ref: main
+          path: reusable-workflows
+
+      - name: Parse PHP versions from composer.json
+        id: parse-php-versions
+        run: |
+          if [ -f composer.json ]; then
+            php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | tr '\n' ',' | sed 's/,$//')
+            if [ -z "$php_versions" ]; then
+              echo "php_versions=default" >> "$GITHUB_OUTPUT"
+            else
+              echo "php_versions=$php_versions" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            exit 1
+          fi
+
+      - name: Set up matrix JSON
+        id: set-matrix
+        run: |
+          php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
+          MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
+          FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '{ include: [ .configs[] | select(.php_version == $php_versions) | .matrix[] ] }')
+          ENCODED_MATRIX_JSON=$(echo "$FILTERED_MATRIX_JSON" | jq -c .)
+          echo "phpstan_matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
+
+  static-analysis:
+    needs: setup-matrix
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-unified.yaml@main
+    with:
+      phpstan_matrix: ${{ needs.setup-matrix.outputs.phpstan_matrix }}
+      private_repo: ${{ needs.setup-matrix.outputs.private_repo }}
+      APP_ENV: test
+      PIMCORE_TEST: 1
+      REQUIRE_ADMIN_BUNDLE: "false"
+      COVERAGE: "none"
+    secrets:
+      SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
+      COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
+      PIMCORE_CI_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}
+      PIMCORE_CI_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_CI_ENCRYPTION_SECRET }}
+      PIMCORE_CI_PRODUCT_KEY: ${{ secrets.PIMCORE_CI_PRODUCT_KEY }}


### PR DESCRIPTION
Fix for the silently-dead static analysis (pimcore/DevOps-Tasks#47): this branch's caller references `reusable-static-analysis-centralized.yaml`, retired from workflows-collection-public on 2025-12-09 — every run since start-failed with zero jobs. Replaced with the unified pattern validated on pimcore/web2print-tools#121 and green on pimcore/system-info-bundle#61 / pimcore/opensearch-client#59.

This lands on the **lowest 12-era branch**: the older branches of this repo cannot install any Pimcore ^10/^11 release under Composer 2.9's Packagist advisory policy (verified in PR runs), so their static analysis stays documented on #47 pending the workflows-owner decision. Forward-merge up the remaining chain follows after merge.

Also carries pimcore/DevOps-Tasks#44 ideas 1–3 in the same file: push scoped to version branches, `concurrency` keyed by PR number (cancels superseded runs, no cross-fork collisions), paths-ignore for docs/assets/markdown.

**Expected on this PR:** static analysis runs real matrix legs.
